### PR TITLE
Corrected compile errors

### DIFF
--- a/webviewer-flutter/lib/main.dart
+++ b/webviewer-flutter/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'dart:ui' as ui;
+import 'dart:ui_web' as ui;
 import 'dart:html' as html;
 
 void main() {
@@ -35,7 +35,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({wkey,required this.title}) : super(key: wkey);
 
   // This widget is the home page of your application. It is stateful, meaning
   // that it has a State object (defined below) that contains fields that affect
@@ -52,24 +52,30 @@ class MyHomePage extends StatefulWidget {
   _MyHomePageState createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+String viewID = "webviewer-id"; 
 
-  String viewID = "webviewer-id";
-  html.DivElement _element;
+class _MyHomePageState extends State<MyHomePage> {
 
   @override
   void initState() {
     super.initState();
 
-    _element = html.DivElement()
+    html.DivElement _element = html.DivElement();
+    _element
       ..id = 'canvas'
+      ..style.height = '100%'
+      ..style.width = '100%'
       ..append(html.ScriptElement()
         ..text = """
-        const canvas = document.querySelector("flt-platform-view").shadowRoot.querySelector("#canvas");
+        // Defines a ShadowRoot within DOM, and is set to 'Open'
+        // Reference: https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot
+        const shadowHost = document.querySelector("flt-platform-view").querySelector("#canvas");
+        const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+
         WebViewer({
           path: 'WebViewer/lib',
           initialDoc: 'https://pdftron.s3.amazonaws.com/downloads/pl/PDFTRON_about.pdf'
-        }, canvas).then((instance) => {
+        }, shadowRoot).then((instance) => {
             // call apis here
         });
         """);

--- a/webviewer-flutter/pubspec.yaml
+++ b/webviewer-flutter/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -27,7 +27,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:

--- a/webviewer-flutter/web/index.html
+++ b/webviewer-flutter/web/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="myapp">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">


### PR DESCRIPTION
1. pubspec.yaml:
    a. Upgraded the lower bound of sdk: to 2.12.0 to enable null safety.
    b. Upgraded cupertino_icons to 1.0.8.

2. web\index.html:
apple-mobile-web-app-capable is deprecated, use mobile-web-app-capable instead.

3. lib\main.dart:
    a. Replaced dart:ui by dart:ui_web, since platformViewRegistry getter is deprecated.
    b. Replaced key by wkey to distinguish it.
    c. declared html.DivElement _element inside _MyHomePageState.
    d. Set the style.height and style.width.
    e. Defined ShadowRoot within DOM, and is set to 'Open'.