### PR TITLE
Dropping webviewer-filehandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Samples showing how to use various WebViewer features.
 - [webviewer-annotations-php](./webviewer-annotations-php) - Save and load annotations with a PHP backend
 - [webviewer-annotations-sqlite3](./webviewer-annotations-sqlite3) - Save annotations into an SQLite3 database with a Node.js backend
 - [webviewer-facial-redaction](./webviewer-facial-redaction) - Redact faces from PDF with WebViewer
-- [webviewer-filehandler](./webviewer-filehandler)  - Load file handlers in Sharepoint
 - [webviewer-user-bookmarks-nodejs](./webviewer-user-bookmarks-nodejs) - Save and load user bookmarks with a Node.js backend
 - [webviewer-barcode](./webviewer-barcode) - Barcode generation with WebViewer
 - [webviewer-react-canvasToPDF](./webviewer-react-canvasToPDF) - Export a canvas to PDF with WebViewer

--- a/lerna.json
+++ b/lerna.json
@@ -13,8 +13,6 @@
       "webviewer-BIM",
       "webviewer-blazor",
       "webviewer-blazor-wasm",
-      "webviewer-collab-sql",
-      "webviewer-cordova",
       "webviewer-cors/webviewer-app",
       "webviewer-cors/webviewer-lib",
       "webviewer-custom-ui",


### PR DESCRIPTION

## Description

1. Leaving off the webviewer-filehandler on this release, we will add later as we resolve both issues below: 
   a) Requires a sharepoint dev tenant to complete test    
   b) Found that using NodeJS v22 there is an issue with .env creation and needs resolution (may need right package update for this issue).   

2. Also removing from lerna.js and readme files a few references to dropped sample projects.

## Resources

N/A

## Checklist

- [x] I understand that this is a public repo and my changes will be publicly visible

_If you are adding a new sample_
- [ ] I have added an entry to the root level README
- [ ] The name of my sample is consistent with the other samples
- [ ] I have added a README to my sample
- [ ] The sample is fully functional
- [ ] I have updated `lerna.json` with the new sample name

_If you are removing an old sample_
- [x] I have removed the entry from the root level README
- [x] I have removed the sample from `lerna.json`