### PR TITLE
Small changes in 3 projects

### DIFF
--- a/webviewer-blazor-wasm/README.md
+++ b/webviewer-blazor-wasm/README.md
@@ -29,4 +29,4 @@ npm install
 npm start
 ```
 
-Navigate to `https://localhost:5000`
+Navigate to `http://localhost:5000`

--- a/webviewer-nuxtjs/components/WebViewer.vue
+++ b/webviewer-nuxtjs/components/WebViewer.vue
@@ -11,7 +11,7 @@ export default {
   },
   mounted () {
     import('@pdftron/webviewer').then(() => {
-      WebViewer({
+      WebViewer.Iframe({
         path: '../webviewer',
         initialDoc: this.url, // replace with your own PDF file
         licenseKey: 'your_license_key' // sign up to get a free trial key at https://dev.apryse.com

--- a/webviewer-offline/package.json
+++ b/webviewer-offline/package.json
@@ -14,6 +14,7 @@
     "@pdftron/webviewer": "^11.2.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "fs-extra": "^11.3.0",
     "eslint-plugin-import": "^2.17.3"
   },
   "dependencies": {


### PR DESCRIPTION
Minor fixes in 3 projects:
• webviewer-blazor-wasm
Fixed README.md "Navigate to http://localhost:5000"

• webviewer-offline
Added 'fs-extra' to package.json

• webviewer-nuxtjs
In the file components\WebViewer.vue, changed WebViewer to WebViewer.Iframe. This is similar to the change by carlolai in https://github.com/ApryseSDK/webviewer-nuxtjs-sample/pull/4 for which he reported Jira ticket https://apryse.atlassian.net/browse/WVR-7227
