### PR TITLE
Move the location of WebViewer assets to be consistent in Next 14 sample

### DIFF
--- a/webviewer-nextjs-14/.gitignore
+++ b/webviewer-nextjs-14/.gitignore
@@ -36,4 +36,4 @@ yarn-error.log*
 next-env.d.ts
 
 !/public
-/public/webviewer/lib/*
+/public/lib/webviewer/*

--- a/webviewer-nextjs-14/src/components/viewer.tsx
+++ b/webviewer-nextjs-14/src/components/viewer.tsx
@@ -14,7 +14,7 @@ export default function Viewer() {
       const WebViewer = module.default;
       WebViewer(
         {
-          path: '/webviewer/lib',
+          path: '/lib/webviewer',
           initialDoc: '/files/webviewerdemodoc.pdf',
           licenseKey: 'your_license_key'  // sign up to get a free trial key at https://dev.apryse.com
         },

--- a/webviewer-nextjs-14/tools/copy-webviewer-files.js
+++ b/webviewer-nextjs-14/tools/copy-webviewer-files.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 
 const copyFiles = async () => {
   try {
-    await fs.copy('./node_modules/@pdftron/webviewer/public', './public/webviewer/lib');
+    await fs.copy('./node_modules/@pdftron/webviewer/public', './public/lib/webviewer');
     console.log('WebViewer files copied over successfully');
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Description

In order to make samples more consistent, the path used for static WebViewer assets has been changed to /lib/webviewer.

No other changes made