### PR TITLE
[Misc] Update to Salesforce Showcase Sample

### DIFF
--- a/webviewer-salesforce/README.md
+++ b/webviewer-salesforce/README.md
@@ -178,7 +178,7 @@ export default class WebViewer extends LightningElement {
       fullAPI: myObj.fullAPI,
       custom: JSON.stringify(myObj),
       initialDoc: 'file.pdf',
-      config: myfilesUrl + '/config.js',
+      config: myfilesUrl + '/config_apex.js',
     }, viewerElement);
 
     viewerElement.addEventListener('ready', () => {

--- a/webviewer-salesforce/force-app/main/default/staticresources/myfiles/config_apex.js
+++ b/webviewer-salesforce/force-app/main/default/staticresources/myfiles/config_apex.js
@@ -23,6 +23,10 @@ window.Core.setOfficeEditorWorkerPath(resourceURL + 'office_edit');
 window.Core.ContentEdit.setWorkerPath(resourceURL + 'content_edit');
 window.Core.ContentEdit.setResourcePath(resourceURL + 'content_edit_resource');
 
+window.Core.setPDFWorkerChunkPaths([
+  resourceURL + 'full_worker_0',
+  resourceURL + 'full_worker_1',
+])
 // pdf workers
 window.Core.setPDFResourcePath(resourceURL + 'resource')
 if (custom.fullAPI) {

--- a/webviewer-salesforce/package.json
+++ b/webviewer-salesforce/package.json
@@ -5,7 +5,7 @@
   "author": "Apryse Systems Inc.",
   "scripts": {
     "postinstall": "node ./utils/webViewerDownloader.js",
-    "optimize" : "cd webviewer && npm install && npm run optimize && cd.. && node ./utils/copyStaticResources.js"
+    "optimize" : "cd webviewer && npm install && npm run optimize && cd .. && node ./utils/copyStaticResources.js"
   },
   "dependencies": {
     "download": "^8.0.0",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
With continuous growing size of PDFNetCWasm.br.wasm file, its size is growing bigger than salesforce governor limits. We split the workers into two with this PR. So now we need to call the code below to properly load these worker files. 
```
window.Core.setPDFWorkerChunkPaths([
  resourceURL + 'full_worker_0',
  resourceURL + 'full_worker_1',
])
```

Also, ran into an issue trying to copy over the generated .zip files and corrected it

## Resources

<!--- Add any relevant resources or links -->

## Checklist

- [ ] I understand that this is a public repo and my changes will be publicly visible

_If you are adding a new sample_
- [ ] I have added an entry to the root level README
- [ ] The name of my sample is consistent with the other samples
- [ ] I have added a README to my sample
- [ ] The sample is fully functional
- [ ] I have updated `lerna.json` with the new sample name

_If you are removing an old sample_
- [ ] I have removed the entry from the root level README
- [ ] I have removed the sample from `lerna.json`