### PR TITLE
Update WebViewer.flexipage-meta.xml

### DIFF
--- a/webviewer-salesforce/force-app/main/default/flexipages/File_Browser.flexipage-meta.xml
+++ b/webviewer-salesforce/force-app/main/default/flexipages/File_Browser.flexipage-meta.xml
@@ -3,6 +3,7 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <identifier>pdftronFilePickerCombobox</identifier>
                 <componentName>pdftronFilePickerCombobox</componentName>
             </componentInstance>
         </itemInstances>

--- a/webviewer-salesforce/force-app/main/default/flexipages/WebViewer.flexipage-meta.xml
+++ b/webviewer-salesforce/force-app/main/default/flexipages/WebViewer.flexipage-meta.xml
@@ -3,6 +3,7 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <identifier>pdftronFilePickerCombobox</identifier>
                 <componentName>pdftronFilePickerCombobox</componentName>
             </componentInstance>
         </itemInstances>
@@ -12,7 +13,8 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
-                <componentName>pdftronWebViewerContainer</componentName>
+                <identifier>pdftronWebviewerContainer</identifier>
+                <componentName>pdftronWebviewerContainer</componentName>
             </componentInstance>
         </itemInstances>
         <name>region3</name>


### PR DESCRIPTION
## Description

Fixed component configuration in WebViewer.flexipage-meta.xml:

- Corrected casing of component name from pdftronWebViewerContainer to pdftronWebviewerContainer
- Added missing identifier fields for component instances

## Resources

Updated file path:
[webviewer-salesforce/force-app/main/default/flexipages/WebViewer.flexipage-meta.xml](https://github.com/ApryseSDK/webviewer-samples/tree/main/webviewer-salesforce/force-app/main/default/flexipages)

## Checklist

- [x] I understand that this is a public repo and my changes will be publicly visible

_If you are adding a new sample_
- [ ] I have added an entry to the root level README
- [ ] The name of my sample is consistent with the other samples
- [ ] I have added a README to my sample
- [ ] The sample is fully functional
- [ ] I have updated `lerna.json` with the new sample name

_If you are removing an old sample_
- [ ] I have removed the entry from the root level README
- [ ] I have removed the sample from `lerna.json`