### PR TITLE
Added import to force app using ESM module

### DIFF
--- a/webviewer-angular/src/app/webviewer/webviewer.component.ts
+++ b/webviewer-angular/src/app/webviewer/webviewer.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
-import WebViewer from '@pdftron/webviewer';
+import WebViewer from '@pdftron/webviewer/webviewer.esm.js';
 
 @Component({
   selector: 'webviewer',

--- a/webviewer-angular/src/webviewer-esm.d.ts
+++ b/webviewer-angular/src/webviewer-esm.d.ts
@@ -1,0 +1,4 @@
+declare module '@pdftron/webviewer/webviewer.esm.js' {
+  import WebViewer from '@pdftron/webviewer';
+  export default WebViewer;
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Addresses v12 demo errors when running the demo ([AS-383](https://apryse.atlassian.net/browse/AS-383
)

1. Added import to /webviewer.esm.js directly to bypass default in package \webviewer-angular\node_modules\@pdftron\webviewer\package.json

2.  Added this new shim file to declare the type and prevent strict TypScript surfacing errors webviewer-angular\src\webviewer-esm.d.ts

Details about this fix, can be found in a slack thread: https://apryse.slack.com/archives/C028B0842/p1781300781522959

To test:
1. Clone repo
2. cd to /webviewer-angular
3. npm install (Use v12.1.0 or later, if not available to install, get experimental build)
4. npm run build
5. npm start
6. WebViewer app should start with a default PDF file as shown in image:

<img width="1753" height="905" alt="image" src="https://github.com/user-attachments/assets/ad00a79a-d383-4f35-9f36-011061b4bab9" />


## Resources

<!--- Add any relevant resources or links -->

## Checklist

- [x] I understand that this is a public repo and my changes will be publicly visible

_If you are adding a new sample_
- [NA] I have added an entry to the root level README
- [NA] The name of my sample is consistent with the other samples
- [NA] I have added a README to my sample
- [x] The sample is fully functional
- [NA] I have updated `lerna.json` with the new sample name

_If you are removing an old sample_
- [ ] I have removed the entry from the root level README
- [ ] I have removed the sample from `lerna.json`